### PR TITLE
Show other include files as well

### DIFF
--- a/build/guide.pl
+++ b/build/guide.pl
@@ -42,6 +42,9 @@ sub do_include {
         push @out, "\n";
         push @out, "<p class='example-filename'><a href='$filename'>$filename</a></p>";
     }
+    else {
+        @out = @lines;
+    }
 
     return join '', @out;
 }


### PR DESCRIPTION
Include files with .inc extension weren't shown. This commit fixes that.
