### PR TITLE
Fix navigation links in chapter 3

### DIFF
--- a/guide/chapter2.txt
+++ b/guide/chapter2.txt
@@ -99,8 +99,8 @@ You could use this for single characters or keywords.
 
 In the next chapter we look some more at how to use lexical rules in a bigger picture.
 
-Next steps
-----------
+Next step
+---------
 
 [Chapter 3: A small language](chapter3.html)
 

--- a/guide/chapter3.txt
+++ b/guide/chapter3.txt
@@ -1,6 +1,8 @@
 Chapter 3 - A small language for declarations
 =============================================
 
+!include "guide/menu.inc"
+
 In this chapter we'll look a small language thats helps a declare which people
 or groups of people are allowed to use something.
 
@@ -184,3 +186,8 @@ and general.
 if the user is denied access. The contructor of the class takes a source string
 in the language that we specified above. The rules that the parser creates
 should be checked in sequence.
+
+Next step
+---------
+
+[Chapter 4: Parsing an expression](chapter4.html)


### PR DESCRIPTION
Chapter 3 missed a link to chapter 4 and a link back to the home page.

Please also update the deployed site since it is already missing some previous contributions (e.g. chapter 3 [doesn't show up in the TOC](https://marpa-guide.github.io/index.html)).